### PR TITLE
feat: Layer 2 jump fallback for non-iTerm2/Terminal hosts

### DIFF
--- a/src/jump.mjs
+++ b/src/jump.mjs
@@ -20,11 +20,21 @@ export function findTty() {
 // TTY matches, and bring exactly that tab to the front. Matching by TTY — not
 // just `activate` — lands on the right tab even with many windows open.
 //
+// Layer 2 (fallback): when neither iTerm2 nor Terminal owns the tty — i.e. the
+// session runs in some other terminal host (VS Code's integrated terminal,
+// Warp, Ghostty…) — there is no AppleScript tab model to target, so just bring
+// that host app to the front by its bundle id (passed as argv 2). App-level
+// only: it can't focus the specific tab, which is the agreed behaviour for
+// non-iTerm2/Terminal hosts. An empty bundle id (e.g. a host that exposes none)
+// degrades to a silent no-op.
+//
 // Whether each app is running is checked via System Events (`(name of
 // processes) contains ...`), NOT pgrep: iTerm's process name is the full bundle
 // path, so `pgrep -x iTerm2` never matched and the whole jump was skipped.
-const JUMP_SCRIPT = `on run argv
+export const JUMP_SCRIPT = `on run argv
   set targetTTY to item 1 of argv
+  set fallbackBID to ""
+  if (count of argv) > 1 then set fallbackBID to item 2 of argv
   tell application "System Events" to set procs to name of processes
   if procs contains "iTerm2" then
     try
@@ -60,6 +70,13 @@ const JUMP_SCRIPT = `on run argv
       end tell
     end try
   end if
+  -- Layer 2: no per-tab match above (some other terminal host). Bring its app
+  -- to the front by bundle id — app-level only, can't target the tab.
+  if fallbackBID is not "" then
+    try
+      tell application id fallbackBID to activate
+    end try
+  end if
 end run`;
 
 // Bring the terminal window/tab running this Claude session to the front, so the
@@ -68,9 +85,13 @@ end run`;
 // permission denied) is swallowed — jumping is a nicety, never load-bearing.
 export function jumpToTerminal() {
   const tty = findTty();
-  if (!tty) return;
+  if (!tty) return; // no controlling tty → not in a terminal (e.g. Desktop) → skip
+  // __CFBundleIdentifier is set by macOS to the GUI app that launched this
+  // process tree, so for a terminal host it's that terminal's bundle id —
+  // exactly what Layer 2 needs. Absent (non-GUI launch) → "" → fallback no-ops.
+  const bid = process.env.__CFBundleIdentifier || "";
   try {
-    execFileSync("/usr/bin/osascript", ["-", tty],
+    execFileSync("/usr/bin/osascript", ["-", tty, bid],
       { input: JUMP_SCRIPT, timeout: 5000, stdio: ["pipe", "ignore", "ignore"] });
   } catch {}
 }

--- a/test/jump.test.mjs
+++ b/test/jump.test.mjs
@@ -1,0 +1,39 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { JUMP_SCRIPT, findTty } from "../src/jump.mjs";
+
+// Layer 1: iTerm2 / Terminal matched precisely by controlling TTY → focus that
+// exact tab. This is the best-experience path and must stay intact.
+test("Layer 1 — matches iTerm2 and Terminal tabs by tty", () => {
+  assert.match(JUMP_SCRIPT, /tell application "iTerm2"/);
+  assert.match(JUMP_SCRIPT, /tell application "Terminal"/);
+  assert.match(JUMP_SCRIPT, /tty of s is targetTTY/, "iTerm2 matches session tty");
+  assert.match(JUMP_SCRIPT, /tty of t is targetTTY/, "Terminal matches tab tty");
+});
+
+// Layer 2: no per-tab match (some other terminal host — VS Code, Warp, Ghostty…)
+// → bring that host app to the front by bundle id. App-level only, no tab focus.
+test("Layer 2 — falls back to activating the host app by bundle id", () => {
+  assert.match(JUMP_SCRIPT, /tell application id fallbackBID to activate/);
+});
+
+test("Layer 2 — fallback fires only AFTER the precise-match blocks", () => {
+  const iterm = JUMP_SCRIPT.indexOf('tell application "iTerm2"');
+  const term = JUMP_SCRIPT.indexOf('tell application "Terminal"');
+  const fb = JUMP_SCRIPT.indexOf("tell application id fallbackBID");
+  assert.ok(iterm >= 0 && term >= 0 && fb >= 0, "all three branches present");
+  assert.ok(fb > iterm && fb > term, "fallback must come after both precise blocks");
+});
+
+test("Layer 2 — guards against an empty bundle id", () => {
+  // fallbackBID defaults to "" and the activate is gated on it being non-empty,
+  // so a host that exposes no bundle id degrades to a silent no-op (e.g. Desktop).
+  assert.match(JUMP_SCRIPT, /set fallbackBID to ""/);
+  assert.match(JUMP_SCRIPT, /if fallbackBID is not ""/);
+});
+
+test("findTty returns a string — \"\" or a /dev path", () => {
+  const t = findTty();
+  assert.equal(typeof t, "string");
+  if (t) assert.match(t, /^\/dev\//);
+});


### PR DESCRIPTION
## Summary

- When neither iTerm2 nor Terminal owns the session tty (VS Code integrated terminal, Warp, Ghostty…), Back now raises the host app via `__CFBundleIdentifier` instead of doing nothing. App-level focus only; iTerm2/Terminal keep precise per-tab matching. Empty bundle id (Claude Desktop — no controlling tty) degrades to a silent no-op.

## Notes

- iTerm2 + Terminal per-tab focus is unchanged; only the no-match fallback is new.
- Not yet verified on real hardware: end-to-end jump in VS Code / Warp, and Claude Desktop hook behaviour. Version bump + npm publish are intentionally deferred until that manual pass.