### PR TITLE
fix(iterate): drop the caller-level concurrency group

### DIFF
--- a/.github/workflows/claude-codex-iterate.yml
+++ b/.github/workflows/claude-codex-iterate.yml
@@ -12,10 +12,6 @@ permissions:
   id-token: write
   actions: read
 
-concurrency:
-  group: claude-codex-${{ github.event.pull_request.number }}
-  cancel-in-progress: false
-
 jobs:
   iterate:
     uses: Melodymaifafa/gh-workflows/.github/workflows/claude-codex-iterate.yml@v1


### PR DESCRIPTION
## Summary

- Remove the top-level `concurrency` block from the `claude-codex-iterate` caller stub. It declared the same group as the reusable workflow it calls, which GitHub treats as a deadlock between "top level workflow" and the job — every trigger failed instantly with zero jobs and no log, so Claude has never once iterated on a Codex review in this repo.

## Notes

- Queueing is unchanged; the group now lives on the called job (Melodymaifafa/gh-workflows#8).
- Takes effect only once the `v1` tag in gh-workflows moves to include that PR.